### PR TITLE
Bump up request and moment versions

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -12,12 +12,12 @@ authenticator.getAccessToken = function(tenantId, spnAppPrincipalId, spnSymmetri
       "aud": "00000001-0000-0000-c000-000000000000/accounts.accesscontrol.windows.net@" + tenantId,
       "iss": spnAppPrincipalId + "@" + tenantId,
       "nbf": moment().unix(),
-      "exp": moment().add('hours', 1).unix()
+      "exp": moment().add(1, 'hours').unix()
   };
 
   var key = new Buffer(spnSymmetricKeyBase64, 'base64').toString('binary');
   var token = jwt.encode(payload, key);
-  var data = { 
+  var data = {
         grant_type: 'http://oauth.net/grant_type/jwt/1.0/bearer',
         assertion: token,
         resource: '00000002-0000-0000-c000-000000000000/directory.windows.net@' + tenantId
@@ -25,7 +25,7 @@ authenticator.getAccessToken = function(tenantId, spnAppPrincipalId, spnSymmetri
 
   request.post('https://accounts.accesscontrol.windows.net/tokens/OAuth/2', { form: data }, function(e, resp, body) {
     if (e) return callback(e, null);
-    
+
     if (resp.statusCode != 200) {
       try {
         var response = JSON.parse(body);
@@ -50,7 +50,7 @@ authenticator.getGraphClient = function (tenantId, spnAppPrincipalId, spnSymmetr
 };
 
 authenticator.getAccessTokenWithClientCredentials = function(tenantDomain, appDomain, clientId, clientSecret, callback) {
-  var data = { 
+  var data = {
         grant_type: 'client_credentials',
         client_id: clientId + '/' + appDomain + '@' + tenantDomain,
         client_secret: clientSecret,
@@ -59,7 +59,7 @@ authenticator.getAccessTokenWithClientCredentials = function(tenantDomain, appDo
 
   request.post('https://accounts.accesscontrol.windows.net/' + tenantDomain + '/tokens/OAuth/2', { form: data }, function(e, resp, body) {
     if (e) return callback(e, null);
-    
+
     if (resp.statusCode != 200) {
       try {
         var response = JSON.parse(body);
@@ -77,7 +77,7 @@ authenticator.getAccessTokenWithClientCredentials = function(tenantDomain, appDo
 };
 
 authenticator.getAccessTokenWithClientCredentials2 = function(tenantDomain, clientId, clientSecret, callback) {
-  var data = { 
+  var data = {
     grant_type: 'client_credentials',
     client_id: clientId,
     client_secret: clientSecret,
@@ -86,7 +86,7 @@ authenticator.getAccessTokenWithClientCredentials2 = function(tenantDomain, clie
 
   request.post('https://login.windows.net/' + tenantDomain + '/oauth2/token', { form: data }, function(e, resp, body) {
     if (e) return callback(e, null);
-    
+
     if (resp.statusCode != 200) {
       try {
         var response = JSON.parse(body);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Matias Woloski",
   "license": "MIT",
   "dependencies": {
-    "request": "~2.11.4",
+    "request": "^2.74.0",
     "jwt-simple": "~0.1.0",
     "moment": "~1.7.2",
     "async": "~0.1.22",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "request": "^2.74.0",
     "jwt-simple": "~0.1.0",
-    "moment": "~1.7.2",
+    "moment": "~2.14.1",
     "async": "~0.1.22",
     "xtend": "~1.0.3"
   }

--- a/test/auth.tests.js
+++ b/test/auth.tests.js
@@ -16,21 +16,21 @@ describe('login to waad', function () {
 
     it('should fail for wrong tenantId', function (done) {
         auth.getAccessToken('wrong-tenant-id', config.v1.APPPRINCIPALID, config.v1.SYMMETRICKEY, function(err, token) {
-            assert.equal('The requested namespace does not exist.', err.message);
+            assert.ok(err.message.indexOf('AADSTS90002: No service namespace named \'wrong-tenant-id\' was found in the data store.'));
             done();
         });
     });
 
     it('should fail for wrong service principal', function (done) {
         auth.getAccessToken(config.v1.TENANTID, 'wrong-principal', config.v1.SYMMETRICKEY, function(err, token) {
-            assert.ok(err.message.indexOf('ACS50027') > -1);
+            assert.ok(err.message.indexOf('AADSTS70001: Application with identifier \'wrong-principal\' was not found in the directory') > -1);
             done();
         });
     });
 
     it('should fail for wrong service key', function (done) {
         auth.getAccessToken(config.v1.TENANTID, config.v1.APPPRINCIPALID, 'wrong-key', function(err, token) {
-            assert.ok(err.message.indexOf('ACS50027') > -1);
+            assert.ok(err.message.indexOf('AADSTS70002: Error validating credentials. AADSTS50012: Client assertion contains an invalid signature.') > -1);
             done();
         });
     });


### PR DESCRIPTION
Bump up request and moment versions due to security vulnerabilities.
Fix some out of date error messages in tests.

Previous `moment().add` signature is deprecated now.

Can you generate a new version? `2.2.1` ?