### PR TITLE
Add Node 6 support

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -15,7 +15,7 @@ authenticator.getAccessToken = function(tenantId, spnAppPrincipalId, spnSymmetri
       "exp": moment().add(1, 'hours').unix()
   };
 
-  var key = new Buffer(spnSymmetricKeyBase64, 'base64').toString('binary');
+  var key = new Buffer(spnSymmetricKeyBase64, 'base64');
   var token = jwt.encode(payload, key);
   var data = {
         grant_type: 'http://oauth.net/grant_type/jwt/1.0/bearer',


### PR DESCRIPTION
Before this change, some tests broke on Node 6 because of the change in the default encoding in crypto-related functions in the new version of Node. After this change, the tests pass on Node 4 and 6.