### PR TITLE
Add top parameter for retrieving more user groups

### DIFF
--- a/lib/waad10.js
+++ b/lib/waad10.js
@@ -61,10 +61,8 @@ Waad10.prototype.__request = function (options, callback) {
 };
 
 Waad10.prototype.__queryNestedUserGroups = function (objectIdOrUpn, callback) {
-  var qs = {
-    "api-version": this.apiVersion,
-    "$top": this.options.maxGroupsToRetrieve || DEFAULT_MAX_GROUPS_TO_RETRIEVE
-  };
+  var qs = {};
+  qs['api-version'] = this.apiVersion;
 
   this.__request({
     url: this.baseUrl + this.options.tenant + '/users/' + objectIdOrUpn + '/getMemberGroups',

--- a/lib/waad10.js
+++ b/lib/waad10.js
@@ -59,8 +59,10 @@ Waad10.prototype.__request = function (options, callback) {
 };
 
 Waad10.prototype.__queryNestedUserGroups = function (objectIdOrUpn, callback) {
-  var qs = {};
-  qs['api-version'] = this.apiVersion;
+  var qs = {
+    "api-version": this.apiVersion,
+    "$top": this.options.maxGroupsToRetrieve || 250
+  };
 
   this.__request({
     url: this.baseUrl + this.options.tenant + '/users/' + objectIdOrUpn + '/getMemberGroups',
@@ -90,8 +92,10 @@ Waad10.prototype.__getObjectsByObjectIds = function (objectIds, callback) {
 };
 
 Waad10.prototype.__queryUserGroup = function (objectIdOrUpn, callback) {
-  var qs = {};
-  qs['api-version'] = this.apiVersion;
+  var qs = {
+    "api-version": this.apiVersion,
+    "$top": this.options.maxGroupsToRetrieve || 250
+  };
 
   this.__request({
     url: this.baseUrl + this.options.tenant + '/users/' + objectIdOrUpn + '/memberOf',

--- a/lib/waad10.js
+++ b/lib/waad10.js
@@ -1,6 +1,8 @@
 var request = require('request');
 var async   = require('async');
 
+var DEFAULT_MAX_GROUPS_TO_RETRIEVE = 250;
+
 module.exports = Waad10;
 
 function Waad10(options) {
@@ -61,7 +63,7 @@ Waad10.prototype.__request = function (options, callback) {
 Waad10.prototype.__queryNestedUserGroups = function (objectIdOrUpn, callback) {
   var qs = {
     "api-version": this.apiVersion,
-    "$top": this.options.maxGroupsToRetrieve || 250
+    "$top": this.options.maxGroupsToRetrieve || DEFAULT_MAX_GROUPS_TO_RETRIEVE
   };
 
   this.__request({
@@ -94,7 +96,7 @@ Waad10.prototype.__getObjectsByObjectIds = function (objectIds, callback) {
 Waad10.prototype.__queryUserGroup = function (objectIdOrUpn, callback) {
   var qs = {
     "api-version": this.apiVersion,
-    "$top": this.options.maxGroupsToRetrieve || 250
+    "$top": this.options.maxGroupsToRetrieve || DEFAULT_MAX_GROUPS_TO_RETRIEVE
   };
 
   this.__request({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-waad",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "query windows azure active directory",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
Currently the `node-waad` library doesn't support passing a limit parameter for retrieving more than a 100 user groups which is the default amount sent by Microsoft. This small change introduces the `top` parameter in the query object. If the option `maxGroupsToRetrieve` is not found, then a default of 250 is sent.