### PR TITLE
Reading entire test config from environment vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test/env.json

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   },
   "repository": "https://github.com/auth0/node-waad",
   "devDependencies": {
+    "lodash": "~1.0.0-rc.3",
     "mocha": "*",
-    "should": "~1.2.1",
-    "lodash": "~1.0.0-rc.3"
+    "nconf": "^0.10.0",
+    "should": "~1.2.1"
   },
   "keywords": [
     "waad",

--- a/test/config.js
+++ b/test/config.js
@@ -28,20 +28,20 @@ module.exports = {
     TENANTID: config('V1_TENANTID'),
     APPPRINCIPALID: config('V1_APPPRINCIPALID'),
     SYMMETRICKEY: config('V1_SYMMETRICKEY'),
-    UPN: config('V1_UPN'),
+    UPN: config('V1_UPN')
   },
   // for waad v2 tests
   v2: {
     WAAD_TENANTDOMAIN: config('V2_WAAD_TENANTDOMAIN'),
     WAAD_CLIENTID: config('V2_WAAD_CLIENTID'),
     WAAD_CLIENTSECRET: config('V2_WAAD_CLIENTSECRET'),
-    UPN: config('V2_UPN'),
+    UPN: config('V2_UPN')
   },
   user: {
     objectId: config('USER_OBJECT_ID'),
     displayName : config('USER_DISPLAY_NAME'),
     groups: config('USER_GROUPS').split(','),
-    allGroups: config('USER_GROUPS').split(','),
+    allGroups: config('USER_GROUPS').split(',')
   },
   invalid_email: config('INVALID_EMAIL')
 };

--- a/test/config.js
+++ b/test/config.js
@@ -1,24 +1,47 @@
+var nconf = require('nconf');
+
+var defaults = {
+  V1_TENANTID: '[tenant-id]',
+  V1_APPPRINCIPALID: '[app-principal-id]',
+  V1_SYMMETRICKEY: '[symmetric-key]',
+  V1_UPN: '[user-upn]',
+  V2_WAAD_TENANTDOMAIN: '[tenant-domain]',
+  V2_WAAD_CLIENTID: '[client-id]',
+  V2_WAAD_CLIENTSECRET: '[client-secret]',
+  V2_UPN: '[user-upn]',
+  USER_OBJECT_ID: '[user-object-id]',
+  USER_DISPLAY_NAME : '[user-display-name]',
+  USER_GROUPS: '[user-groups]',
+  INVALID_EMAIL: '[invalid-email]'
+};
+
+nconf
+  .env()
+  .file('./test/env.json')
+  .required(Object.keys(defaults)); // Require this file exist in order to run tests - fail hard and fast
+
+var config = nconf.get.bind(nconf);
+
 module.exports = {
-  // for v1 accesss_tokens tests
+  // for v1 access_tokens tests
   v1: {
-    TENANTID: process.env.TENANTID || '[tenant-id]',
-    APPPRINCIPALID: process.env.APPPRINCIPALID || '[app-principal-id]',
-    SYMMETRICKEY: process.env.SYMMETRICKEY || '[symmetric-key]',
-    UPN: '[user-upn]',
+    TENANTID: config('V1_TENANTID'),
+    APPPRINCIPALID: config('V1_APPPRINCIPALID'),
+    SYMMETRICKEY: config('V1_SYMMETRICKEY'),
+    UPN: config('V1_UPN'),
   },
   // for waad v2 tests
   v2: {
-    WAAD_TENANTDOMAIN: process.env.WAAD_TENANTDOMAIN || '[tenant-domain]',
-    WAAD_CLIENTID: process.env.WAAD_CLIENTID || '[client-id]',
-    WAAD_CLIENTSECRET: process.env.WAAD_CLIENTSECRET || '[client-secret]',
-    UPN: '[user-upn]',
+    WAAD_TENANTDOMAIN: config('V2_WAAD_TENANTDOMAIN'),
+    WAAD_CLIENTID: config('V2_WAAD_CLIENTID'),
+    WAAD_CLIENTSECRET: config('V2_WAAD_CLIENTSECRET'),
+    UPN: config('V2_UPN'),
   },
   user: {
-    objectId: '[sample-user-object-id]',
-    displayName : '[sample-user-display-name]',
-    groups: ['[sample-user-direct-groups]'],
-    allGroups: ['[sample-user-groups]']
+    objectId: config('USER_OBJECT_ID'),
+    displayName : config('USER_DISPLAY_NAME'),
+    groups: config('USER_GROUPS').split(','),
+    allGroups: config('USER_GROUPS').split(','),
   },
-
-  invalid_email: '[invalid-user]',
+  invalid_email: config('INVALID_EMAIL')
 };


### PR DESCRIPTION
## ✏️ Changes

Previously the tests could not be run locally with the config.json that is
provided with the repository. One would instead need to copy a config given by
Crew Auth directly into the project. This doesn't scale well, nor does it work
with CI, so I've instead added `nconf` and read env vars from `env.json` if the
environment variables are unavailable on the server.

The app will fail to run the tests if the file or environment variables are not
present. env.json is not tracked by version control.

### There are NO production code changes, only test.

## 🎯 Testing

- Obtain the test file from me
- Run the test suite to ensure everything still passes