### PR TITLE
Add functional tests with #10

### DIFF
--- a/lib/waad10.js
+++ b/lib/waad10.js
@@ -59,8 +59,9 @@ Waad10.prototype.__request = function (options, callback) {
 };
 
 Waad10.prototype.__queryNestedUserGroups = function (objectIdOrUpn, callback) {
-  var qs = {};
-  qs['api-version'] = this.apiVersion;
+  var qs = {
+    "api-version": this.apiVersion
+  };
 
   this.__request({
     url: this.baseUrl + this.options.tenant + '/users/' + objectIdOrUpn + '/getMemberGroups',
@@ -90,8 +91,10 @@ Waad10.prototype.__getObjectsByObjectIds = function (objectIds, callback) {
 };
 
 Waad10.prototype.__queryUserGroup = function (objectIdOrUpn, callback) {
-  var qs = {};
-  qs['api-version'] = this.apiVersion;
+  var qs = {
+    "api-version": this.apiVersion,
+    "$top": this.options.maxGroupsToRetrieve || 250
+  };
 
   this.__request({
     url: this.baseUrl + this.options.tenant + '/users/' + objectIdOrUpn + '/memberOf',

--- a/lib/waad10.js
+++ b/lib/waad10.js
@@ -1,6 +1,8 @@
 var request = require('request');
 var async   = require('async');
 
+var DEFAULT_MAX_GROUPS_TO_RETRIEVE = 250;
+
 module.exports = Waad10;
 
 function Waad10(options) {
@@ -93,7 +95,7 @@ Waad10.prototype.__getObjectsByObjectIds = function (objectIds, callback) {
 Waad10.prototype.__queryUserGroup = function (objectIdOrUpn, callback) {
   var qs = {
     "api-version": this.apiVersion,
-    "$top": this.options.maxGroupsToRetrieve || 250
+    "$top": this.options.maxGroupsToRetrieve || DEFAULT_MAX_GROUPS_TO_RETRIEVE
   };
 
   this.__request({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-waad",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "query windows azure active directory",
   "main": "./lib",
   "scripts": {

--- a/test/waad1.0.tests.js
+++ b/test/waad1.0.tests.js
@@ -4,6 +4,62 @@ var assert = require('assert')
   , config = require('./config');
 
 
+describe('setting maximum groups to retrieve', function() {
+  // Explicitly call out this sketchy action
+  // Forwarding internal params to mock
+  var mockObjectUnderTest = function(obj) {
+    obj.__request = function(params, cb) {
+      cb(params);
+    };
+  };
+
+  it('defaults to 250 if unset', function(done) {
+    var waad = new Waad({
+      tenant: config.v2.WAAD_TENANTDOMAIN,
+      accessToken: 'abc123'
+    });
+
+    mockObjectUnderTest(waad);
+
+    waad.getGroupsForUserByObjectIdOrUpn('foo@example.com', function(mockParams) {
+      assert.equal(mockParams.qs.$top, 250);
+      done();
+    });
+  });
+
+  it('will pass the group max to the api', function(done) {
+    var waad = new Waad({
+      tenant: config.v2.WAAD_TENANTDOMAIN,
+      accessToken: 'abc123',
+      maxGroupsToRetrieve: 555
+    });
+
+    mockObjectUnderTest(waad);
+
+    waad.getGroupsForUserByObjectIdOrUpn('foo@example.com', function(mockParams) {
+      assert.equal(mockParams.qs.$top, 555);
+      done();
+    });
+  });
+
+  it('will pass the group max to the api with nested user groups', function(done) {
+    var waad = new Waad({
+      tenant: config.v2.WAAD_TENANTDOMAIN,
+      accessToken: 'abc123',
+      includeNestedGroups: true,
+      maxGroupsToRetrieve: 555
+    });
+
+    mockObjectUnderTest(waad);
+
+    waad.getGroupsForUserByObjectIdOrUpn('foo@example.com', function(mockParams) {
+      assert.equal(mockParams.qs.$top, 555);
+      done();
+    });
+  });
+});
+
+
 describe('query graph api-version 1.0', function () {
   before(function(done) {
 


### PR DESCRIPTION
Currently the `node-waad` library doesn't support passing a limit parameter for retrieving more than a 100 user groups which is the default amount sent by Microsoft. This small change introduces the `top` parameter in the query object. If the option `maxGroupsToRetrieve` is not found, then a default of 250 is sent.