### PR TITLE
Handle uncaught errors in auth.js

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -18,27 +18,31 @@ authenticator.getAccessToken = function(tenantId, spnAppPrincipalId, spnSymmetri
   var key = new Buffer(spnSymmetricKeyBase64, 'base64');
   var token = jwt.encode(payload, key);
   var data = {
-        grant_type: 'http://oauth.net/grant_type/jwt/1.0/bearer',
-        assertion: token,
-        resource: '00000002-0000-0000-c000-000000000000/directory.windows.net@' + tenantId
-         };
+    grant_type: 'http://oauth.net/grant_type/jwt/1.0/bearer',
+    assertion: token,
+    resource: '00000002-0000-0000-c000-000000000000/directory.windows.net@' + tenantId
+  };
 
   request.post('https://accounts.accesscontrol.windows.net/tokens/OAuth/2', { form: data }, function(e, resp, body) {
     if (e) return callback(e, null);
 
+    var parsedBody;
+
+    try {
+      parsedBody = JSON.parse(body);
+    } catch(e){
+      return callback(new Error('Failed to parse response from graph API'));
+    }
+
     if (resp.statusCode != 200) {
-      try {
-        var response = JSON.parse(body);
-        if (response.error) {
-          return callback(new OAuthError(response.error_description || response.error, response), null);
-        }
+      if (parsedBody.error) {
+        return callback(new OAuthError(parsedBody.error_description || parsedBody.error, parsedBody), null);
       }
-      catch(err) {}
 
       return callback(new OAuthError(body), null);
     }
 
-    callback(null, JSON.parse(body).access_token);
+    callback(null, parsedBody.access_token);
   });
 };
 
@@ -51,28 +55,32 @@ authenticator.getGraphClient = function (tenantId, spnAppPrincipalId, spnSymmetr
 
 authenticator.getAccessTokenWithClientCredentials = function(tenantDomain, appDomain, clientId, clientSecret, callback) {
   var data = {
-        grant_type: 'client_credentials',
-        client_id: clientId + '/' + appDomain + '@' + tenantDomain,
-        client_secret: clientSecret,
-        resource: '00000002-0000-0000-c000-000000000000/graph.windows.net@' + tenantDomain
-         };
+    grant_type: 'client_credentials',
+    client_id: clientId + '/' + appDomain + '@' + tenantDomain,
+    client_secret: clientSecret,
+    resource: '00000002-0000-0000-c000-000000000000/graph.windows.net@' + tenantDomain
+  };
 
   request.post('https://accounts.accesscontrol.windows.net/' + tenantDomain + '/tokens/OAuth/2', { form: data }, function(e, resp, body) {
     if (e) return callback(e, null);
 
+    var parsedBody;
+
+    try {
+      parsedBody = JSON.parse(body);
+    } catch(e){
+      return callback(new Error('Failed to parse response from graph API'));
+    }
+
     if (resp.statusCode != 200) {
-      try {
-        var response = JSON.parse(body);
-        if (response.error) {
-          return callback(new OAuthError(response.error_description || response.error, response), null);
-        }
+      if (parsedBody.error) {
+        return callback(new OAuthError(parsedBody.error_description || parsedBody.error, parsedBody), null);
       }
-      catch (exp) {}
 
       return callback(new OAuthError(body), null);
     }
 
-    callback(null, JSON.parse(body).access_token);
+    callback(null, parsedBody.access_token);
   });
 };
 
@@ -87,19 +95,23 @@ authenticator.getAccessTokenWithClientCredentials2 = function(tenantDomain, clie
   request.post('https://login.windows.net/' + tenantDomain + '/oauth2/token', { form: data }, function(e, resp, body) {
     if (e) return callback(e, null);
 
+    var parsedBody;
+
+    try {
+      parsedBody = JSON.parse(body);
+    } catch(e){
+      return callback(new Error('Failed to parse response from graph API'));
+    }
+
     if (resp.statusCode != 200) {
-      try {
-        var response = JSON.parse(body);
-        if (response.error) {
-          return callback(new OAuthError(response.error_description || response.error, response), null);
-        }
+      if (parsedBody.error) {
+        return callback(new OAuthError(parsedBody.error_description || parsedBody.error, parsedBody), null);
       }
-      catch (exp) {}
 
       return callback(new OAuthError(body), null);
     }
 
-    callback(null, JSON.parse(body).access_token);
+    callback(null, parsedBody.access_token);
   });
 };
 
@@ -123,5 +135,4 @@ authenticator.getGraphClient10 = function(tenantDomain, clientId, clientSecret, 
     return callback(null, new GraphClient10({tenant: tenantDomain, accessToken: token}));
   });
 };
-
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -30,8 +30,14 @@ authenticator.getAccessToken = function(tenantId, spnAppPrincipalId, spnSymmetri
 
     try {
       parsedBody = JSON.parse(body);
-    } catch(e){
-      return callback(new Error('Failed to parse response from graph API'));
+    } catch (e) {
+      var message = e.message || 'Failed to parse response from graph API';
+      var parseError = new Error(message);
+
+      parseError.name = e.name || 'waad_parse_error';
+      parseError.stack = e.stack;
+      parseError.body = body;
+      return callback(parseError);
     }
 
     if (resp.statusCode != 200) {
@@ -69,7 +75,13 @@ authenticator.getAccessTokenWithClientCredentials = function(tenantDomain, appDo
     try {
       parsedBody = JSON.parse(body);
     } catch(e){
-      return callback(new Error('Failed to parse response from graph API'));
+      var message = e.message || 'Failed to parse response from graph API';
+      var parseError = new Error(message);
+
+      parseError.name = e.name || 'waad_parse_error';
+      parseError.stack = e.stack;
+      parseError.body = body;
+      return callback(parseError);
     }
 
     if (resp.statusCode != 200) {
@@ -100,7 +112,13 @@ authenticator.getAccessTokenWithClientCredentials2 = function(tenantDomain, clie
     try {
       parsedBody = JSON.parse(body);
     } catch(e){
-      return callback(new Error('Failed to parse response from graph API'));
+      var message = e.message || 'Failed to parse response from graph API';
+      var parseError = new Error(message);
+
+      parseError.name = e.name || 'waad_parse_error';
+      parseError.stack = e.stack;
+      parseError.body = body;
+      return callback(parseError);
     }
 
     if (resp.statusCode != 200) {

--- a/lib/waad.js
+++ b/lib/waad.js
@@ -39,7 +39,13 @@ Waad.prototype.__queryUserGroup = function (user, headers, callback) {
     try {
       parsedBody = JSON.parse(body);
     } catch(e){
-      return callback(new Error('Failed to parse response from graph API'));
+      var message = e.message || 'Failed to parse response from graph API';
+      var parseError = new Error(message);
+
+      parseError.name = e.name || 'waad_parse_error';
+      parseError.stack = e.stack;
+      parseError.body = body;
+      return callback(parseError);
     }
 
     var groups = parsedBody.d.results;
@@ -74,7 +80,13 @@ Waad.prototype.__queryUsers = function (qs, options, callback) {
     try {
       parsedBody = JSON.parse(body);
     } catch (e){
-      return callback(new Error('Failed to parse response from graph API'));
+      var message = e.message || 'Failed to parse response from graph API';
+      var parseError = new Error(message);
+
+      parseError.name = e.name || 'waad_parse_error';
+      parseError.stack = e.stack;
+      parseError.body = body;
+      return callback(parseError);
     }
 
     var d = parsedBody.d,

--- a/lib/waad10.js
+++ b/lib/waad10.js
@@ -49,7 +49,13 @@ Waad10.prototype.__request = function (options, callback) {
       try {
         array = JSON.parse(body);
       } catch (e){
-        return callback(new Error('Failed to parse response from graph API'));
+        var message = e.message || 'Failed to parse response from graph API';
+        var parseError = new Error(message);
+
+        parseError.name = e.name || 'waad_parse_error';
+        parseError.stack = e.stack;
+        parseError.body = body;
+        return callback(parseError);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lodash": "~1.0.0-rc.3",
     "mocha": "*",
     "nconf": "^0.10.0",
+    "nock": "^10.0.1",
     "should": "~1.2.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-waad",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "query windows azure active directory",
   "main": "./lib",
   "scripts": {

--- a/test/auth.tests.js
+++ b/test/auth.tests.js
@@ -1,37 +1,38 @@
 var assert = require('assert')
-    , auth = require("../lib/auth")
-    , config = require('./config');
+  , auth = require("../lib/auth")
+  , config = require('./config');
 
 describe('login to waad', function () {
-    it('should obtain an access token', function (done) {
-        auth.getAccessToken(config.v1.TENANTID, config.v1.APPPRINCIPALID, config.v1.SYMMETRICKEY, function(err, token) {
-            if (err) {
-                console.log(err);
-            }
+  it('should obtain an access token', function (done) {
+    auth.getAccessToken(config.v1.TENANTID, config.v1.APPPRINCIPALID, config.v1.SYMMETRICKEY, function(err, token) {
+      if (err) {
+        console.log(err);
+        return done(err);
+      }
 
-            assert.notEqual(null, token);
-            done();
-        });
+      assert.notEqual(null, token);
+      done();
     });
+  });
 
-    it('should fail for wrong tenantId', function (done) {
-        auth.getAccessToken('wrong-tenant-id', config.v1.APPPRINCIPALID, config.v1.SYMMETRICKEY, function(err, token) {
-            assert.ok(err.message.indexOf('AADSTS90002: No service namespace named \'wrong-tenant-id\' was found in the data store.'));
-            done();
-        });
+  it('should fail for wrong tenantId', function (done) {
+    auth.getAccessToken('wrong-tenant-id', config.v1.APPPRINCIPALID, config.v1.SYMMETRICKEY, function(err, token) {
+      assert.ok(err.message.indexOf('AADSTS90002: No service namespace named \'wrong-tenant-id\' was found in the data store.'));
+      done();
     });
+  });
 
-    it('should fail for wrong service principal', function (done) {
-        auth.getAccessToken(config.v1.TENANTID, 'wrong-principal', config.v1.SYMMETRICKEY, function(err, token) {
-            assert.ok(err.message.indexOf('AADSTS70001: Application with identifier \'wrong-principal\' was not found in the directory') > -1);
-            done();
-        });
+  it('should fail for wrong service principal', function (done) {
+    auth.getAccessToken(config.v1.TENANTID, 'wrong-principal', config.v1.SYMMETRICKEY, function(err, token) {
+      assert.ok(err.message.indexOf('AADSTS70001: Application with identifier \'wrong-principal\' was not found in the directory') > -1);
+      done();
     });
+  });
 
-    it('should fail for wrong service key', function (done) {
-        auth.getAccessToken(config.v1.TENANTID, config.v1.APPPRINCIPALID, 'wrong-key', function(err, token) {
-            assert.ok(err.message.indexOf('AADSTS70002: Error validating credentials. AADSTS50012: Client assertion contains an invalid signature.') > -1);
-            done();
-        });
+  it('should fail for wrong service key', function (done) {
+    auth.getAccessToken(config.v1.TENANTID, config.v1.APPPRINCIPALID, 'wrong-key', function(err, token) {
+      assert.ok(err.message.indexOf('AADSTS70002: Error validating credentials. AADSTS50012: Client assertion contains an invalid signature.') > -1);
+      done();
     });
+  });
 });

--- a/test/auth2.tests.js
+++ b/test/auth2.tests.js
@@ -1,0 +1,72 @@
+var assert = require('assert')
+  , auth = require('../lib/auth')
+  , config = require('./config')
+  , nock = require('nock');
+
+describe('login to waad', function () {
+  function assertParseError(actual, expected, token) {
+    assert.deepEqual(actual, expected);
+    assert.equal(token, null);
+  }
+
+  var message = 'Failed to parse response from graph API';
+  var parseError = new Error(message);
+
+  parseError.name = 'waad_parse_error';
+  parseError.stack = 'Error stack'
+  parseError.body = { error: 'body' };
+
+  var tenantId = config.v1.TENANTID;
+  var spnAppPrincipalId = config.v1.APPPRINCIPALID;
+  var spnSymmetricKeyBase64 = config.v1.SYMMETRICKEY;
+  var tenantDomain = config.v2.WAAD_TENANTDOMAIN;
+  var clientId = config.v2.WAAD_CLIENTID;
+  var clientSecret = config.v2.WAAD_CLIENTSECRET;
+
+  describe('v1 fails to parse JSON response', function () {
+    afterEach(function () {
+      nock.cleanAll();
+    });
+
+    it('should return error details when it fails to parse the JSON response when getting an access token', function (done) {
+      nock('https://accounts.accesscontrol.windows.net')
+        .post('/tokens/OAuth/2')
+        .replyWithError(parseError);
+
+      auth.getAccessToken(tenantId, spnAppPrincipalId, spnSymmetricKeyBase64, function(err, token) {
+        assertParseError(err, parseError, token);
+        done();
+      });
+    });
+
+    it('should return error details when it fails to parse the JSON response when getting an access token with client credentials', function (done) {
+      nock('https://accounts.accesscontrol.windows.net')
+        .post('/' + tenantId + '/tokens/OAuth/2')
+        .replyWithError(parseError);
+
+      auth.getAccessTokenWithClientCredentials(tenantId, spnAppPrincipalId, clientId, clientSecret, function(err, token) {
+        assertParseError(err, parseError, token);
+        done();
+      });
+    });
+  });
+
+  describe('v2 fails to parse JSON response', function () {
+    beforeEach(function () {
+      nock('https://login.windows.net')
+        .post('/' + tenantDomain + '/oauth2/token')
+        .replyWithError(parseError);
+    });
+
+    afterEach(function () {
+      nock.cleanAll();
+    });
+
+    it('should return error details when it fails to parse the JSON response', function (done) {
+      auth.getAccessTokenWithClientCredentials2(tenantDomain, clientId, clientSecret, function(err, token) {
+        assertParseError(err, parseError, token);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR wraps the JSON.parse calls in `auth.js` in try catch blocks and returns an error in the callback. This avoids uncaught errors when parsing the response from the request for an access token.